### PR TITLE
Add options max pain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,20 @@ CSV files.
 ## Usage
 
 Run `coinglass_scraper.py` to fetch a few example indicators (fear and
-greed history, funding rates, and open interest history). A Coinglass API
-key can be supplied via the `--api-key` option if the API endpoint
-requires authentication.
+greed history, funding rates, open interest history, and option max pain).
+A Coinglass API key can be supplied via the `--api-key` option or through
+the `COINGLASS_API_KEY` environment variable if the API endpoint requires
+authentication.
 
 ```bash
 python coinglass_scraper.py --symbol BTC --output-dir data
+```
+
+Include the `--exchange` option when retrieving option data (defaults to
+`Deribit`):
+
+```bash
+python coinglass_scraper.py --symbol BTC --exchange Deribit --output-dir data
 ```
 
 Each indicator is saved as a separate CSV file inside the specified


### PR DESCRIPTION
## Summary
- add support for options max pain endpoint
- read API key from the `COINGLASS_API_KEY` environment variable
- allow specifying exchange
- document usage updates

## Testing
- `python coinglass_scraper.py --help`